### PR TITLE
Push container in local dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,4 @@ build: lint
 
 release: lint
 	@WORKINGDIR=$(pwd) goreleaser release --snapshot --rm-dist
+	@docker push ghcr.io/chelnak/cat-team-github-metrics:dev


### PR DESCRIPTION
This PR adds a docker push command to the Makefile. It enables the
developer to push and update a dev tag for faster iteration.